### PR TITLE
Fix bug where logged-in users can't see org details

### DIFF
--- a/web/src/app/org-detail/org-detail.component.ts
+++ b/web/src/app/org-detail/org-detail.component.ts
@@ -79,7 +79,7 @@ export class OrgDetailComponent {
       if (!user || !org) {
         return false;
       }
-      return user.admin || user.manages.some((m) => m.id === org.id);
+      return user.admin || user.manages?.some((m) => m.id === org.id);
     },
   );
   editMode: boolean = false;


### PR DESCRIPTION
If someone was logged in, they couldn't see org details unless they manage the org. This fixes that.